### PR TITLE
fix: switch TypeScript target to es2022 to resolve missing module error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "ESNext",
-    "lib": ["ES2020"],
+    "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
   entry: "./src/index.ts",
   platform: "neutral",
-  target: "es2020",
+  target: "es2022",
   format: ["esm", "cjs"],
   outDir: "./dist",
   dts: true,


### PR DESCRIPTION
This PR updates the TypeScript `target` in our configuration from `es2020` to `es2022`. The change addresses a runtime error where the application failed to find the module `@oxc-project/runtime/helpers/defineProperty` when running the compiled output.

With the previous `es2020` target, TypeScript emitted code that relied on certain runtime helpers which were not available in the installed version, causing the build to break at runtime. By switching to `es2022`, TypeScript emits more modern JavaScript that no longer depends on these problematic helpers, resulting in successful builds and runtime compatibility with our dependencies.

When I added the bundler before, I tested the setup locally (linking with bun), and because of that, the error did not occur.

I now manually copied the dist folder over without linking it and tested it then. It works now.