### PR TITLE
fix(changes): correct person changes endpoint to /person/changes

### DIFF
--- a/src/endpoints/changes.ts
+++ b/src/endpoints/changes.ts
@@ -48,7 +48,7 @@ export class ChangeEndpoint extends BaseEndpoint {
 	 */
 	async person(options?: ChangeOption): Promise<MediaChanges> {
 		return await this.api.get<MediaChanges>(
-			"/person/change",
+			"/person/changes",
 			options as Record<string, unknown>,
 		);
 	}


### PR DESCRIPTION
The endpoint for person changes was incorrectly set to '/person/change' (singular). This commit updates it to the correct '/person/changes' (plural) as per TMDB API docs.